### PR TITLE
Add vertical load and pointing accuracy targets

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -4,7 +4,7 @@
 
 * Az/El antenna rotator hardware
 * Capable of pointing a 2.1 meter dish with associated electronics
-  * Maximum weight of dish and electronics (Vertical Load): nnn kg
+  * Maximum weight of dish and electronics (Vertical Load): 50 kg
 * All open source
 * When possible, standard, easily sourced components should be used
 * Movement speed capable of tracking LEO satellites
@@ -18,8 +18,8 @@
   * Elevation: nnn N&sdot;m
   * Azimuth: nnn N&sdot;m
 * Pointing Accuracy
-  * Elevation:  &pm;nnn&deg;
-  * Azimuth: &pm;nnn&deg;
+  * Elevation:  &pm;0.1&deg;
+  * Azimuth: &pm;0.1&deg;
 * Range of Travel
   * Elevation: 0.00&deg; to +180.00&deg;
   * Azimuth: 0.00&deg; to +450.00&deg;


### PR DESCRIPTION
There wasn't much feedback on the vertical load discussion (on Slack).  A 1m steel dish weighed in at about 12kg.  Commercial rotors have very large vertical load maximums, probably because this isn't going to be the real limiter.  Just so we don't go too overboard, I'm suggesting a limit of 50kg (dish plus electronics).

Pointing accuracy is an interesting one and could use more discussion/evaluation.  Back of the envelope for extreme case - 2.1 meter dish, 50GHz, 0.2 degree 3dB beam width - would be nice to point within 0.1 degrees minimum accuracy to peak a signal.  50GHz is outside our current needs, might be within the use case in the future, and shooting for it only makes pointing at the lower frequencies more accurate.  I can definitely see arguments that 0.1 degrees isn't enough.  For example, at far distances 0.1 degrees is a pretty wide swath to be swinging for a peak.  0.1 degrees is on par with the higher end commercial rotors, is used by amateur deep space monitoring enthusiasts, and exceeds the specifications of the popular Yaesu rotor.